### PR TITLE
Add wait-for-it in run-fac-ps-ioc.sh

### DIFF
--- a/host/function/scripts/ps-ioc-config-files/run-fac-ps-ioc.sh
+++ b/host/function/scripts/ps-ioc-config-files/run-fac-ps-ioc.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 
-systemctl start sirius-bbb-ioc-ps.service
 
-# if [ ! -d "/root/sirius-ioc-as-ps" ]; then
-#     mkdir -p /root/sirius-ioc-as-ps
-# fi
-# DATE=`date '+%Y-%m-%d_%Hh%Mm%Ss'`
-# sirius-ioc-as-ps.py --hostname >> /root/sirius-ioc-as-ps/$DATE.log 2>&1 &
+# Wait until servweb is up and running
+wait-for-it -t 0 10.128.255.5:80
+wait-for-it -t 0 10.128.255.5:20080
+
+# Run PS IOC systemd service
+systemctl start sirius-bbb-ioc-ps.service


### PR DESCRIPTION
- Tested OK in **IA-01RaCtrl:CO-PSCtrl-BO**. Waited 5 mins before web server was up. Continued when wev server was already up...
- !!! ONLY MERGE WHEN *wait-for-it* IS INSTALLED IN ALL POWER SUPPLY BEAGLEBONES