### PR TITLE
Disable sirius-bbb-ioc-as-ps.service in BBBs at boottime

### DIFF
--- a/host/function/scripts/ps-ioc-config-files/run-fac-ps-ioc.sh
+++ b/host/function/scripts/ps-ioc-config-files/run-fac-ps-ioc.sh
@@ -3,8 +3,8 @@
 
 
 # Wait until servweb is up and running
-wait-for-it -t 0 10.128.255.5:80
-wait-for-it -t 0 10.128.255.5:20080
+#wait-for-it -t 0 10.128.255.5:80
+#wait-for-it -t 0 10.128.255.5:20080
 
 # Run PS IOC systemd service
-systemctl start sirius-bbb-ioc-ps.service
+#systemctl start sirius-bbb-ioc-ps.service

--- a/host/function/scripts/ps-ioc-config-files/sync-fac-files.sh
+++ b/host/function/scripts/ps-ioc-config-files/sync-fac-files.sh
@@ -12,5 +12,4 @@ pushd /root/bbb-daemon/host/rsync
     # Writing new values, described below
     sed -i -e '1i\127.0.0.1    localhost' -e '1i\127.0.1.1    '"$hn" /etc/hosts
     sed -i -e '$a\'"#"' sirius-consts server alias' -e '$a\10.128.255.5 sirius-consts.lnls.br servweb' /etc/hosts
-
 popd


### PR DESCRIPTION
Please let **me** merge this PR so that I am aware of when I need to choose to manually start either eth-based or serial-based PS IOCs...