### PR TITLE
Comment out fac packages synchronization in BBBs

### DIFF
--- a/host/function/scripts/ps-ioc-config-files/sync-fac-files.sh
+++ b/host/function/scripts/ps-ioc-config-files/sync-fac-files.sh
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 
 pushd /root/bbb-daemon/host/rsync
-    ./rsync_beaglebone.sh mathphys
-    ./rsync_beaglebone.sh dev-packages
-    ./rsync_beaglebone.sh machine-applications
+    # ./rsync_beaglebone.sh mathphys
+    # ./rsync_beaglebone.sh dev-packages
+    # ./rsync_beaglebone.sh machine-applications
     hn=$(hostname)
     # Removing old entries
     sed -i -e '/sirius/d' /etc/hosts


### PR DESCRIPTION
For the time being, in order to speed up beaglebone reboot process, we may comment out synchronization of FAC packages that are necessary for the IOCs running the beaglebones.